### PR TITLE
update template to be a const and avoid this dependency when running …

### DIFF
--- a/pkg/leaderboard/leaderboard.go
+++ b/pkg/leaderboard/leaderboard.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -39,10 +38,8 @@ type item struct {
 
 // Render returns an HTML formatted leaderboard page
 func Render(title string, since time.Time, until time.Time, prs []*repo.PRSummary, reviews []*repo.ReviewSummary, issues []*repo.IssueSummary, comments []*repo.CommentSummary) (string, error) {
-	files := []string{"pkg/leaderboard/leaderboard.tmpl"}
-	name := path.Base(files[0])
 	funcMap := template.FuncMap{}
-	tmpl, err := template.New(name).Funcs(funcMap).ParseFiles(files...)
+	tmpl, err := template.New("LeaderBoard").Funcs(funcMap).Parse(leaderboardTmpl)
 	if err != nil {
 		return "", fmt.Errorf("parsefiles: %v", err)
 	}

--- a/pkg/leaderboard/leaderboard_templage.go
+++ b/pkg/leaderboard/leaderboard_templage.go
@@ -1,8 +1,10 @@
-<html>
+package leaderboard
+
+const leaderboardTmpl = `<html>
 <head>
     <title>{{ .Title }} - Leaderboard</title>
     <link rel="preconnect" href="https://fonts.gstatic.com">
-    <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600;700&display=swap" rel="stylesheet"> 
+    <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600;700&display=swap" rel="stylesheet">
     <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
     <script type="text/javascript">
         google.charts.load("current", {packages:["corechart"]});
@@ -18,12 +20,12 @@
       color: rgba(66,133,244);
       margin-bottom: 0em;
     }
- 
+
     .subtitle {
       color: rgba(23,90,201);
       font-size: small;
     }
-    
+
     pre {
         white-space: pre-wrap;
         word-wrap: break-word;
@@ -126,3 +128,4 @@
     {{ end}}
 </body>
 </html>
+`


### PR DESCRIPTION
…the service outside of the project repo


I did the `go get github.com/google/pullsheet` to install the binary in my path and then I run the pullsheet outside of the project repo and got an error:

`F0226 16:11:54.215001   26719 pullsheet.go:157] generate failed: parsefiles: open pkg/leaderboard/leaderboard.tmpl: no such file or directory`

This PR address this by making a const var to store the template. 
Maybe in the future, we can pass it as a flag to a custom template

/assign @tstromberg 