### PR TITLE
Add basic .gitignore to project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# macOS
+.DS_Store
+
+# goland, IntelliJ
+.idea
+
+# binaries
+pullsheet


### PR DESCRIPTION
Currently handles .DS_Store files, intellij files, and pullsheet binary output from `go build`