### PR TITLE
Change how tokens are handled

### DIFF
--- a/cmd/issues-comments.go
+++ b/cmd/issues-comments.go
@@ -42,7 +42,7 @@ func init() {
 
 func runIssueComments(rootOpts *rootOptions) error {
 	ctx := context.Background()
-	c, err := client.New(ctx, rootOpts.tokenPath)
+	c, err := client.New(ctx, rootOpts.token)
 	if err != nil {
 		return err
 	}

--- a/cmd/issues.go
+++ b/cmd/issues.go
@@ -43,7 +43,7 @@ func init() {
 
 func runIssues(rootOpts *rootOptions) error {
 	ctx := context.Background()
-	c, err := client.New(ctx, rootOpts.tokenPath)
+	c, err := client.New(ctx, rootOpts.token)
 	if err != nil {
 		return err
 	}

--- a/cmd/leaderboard.go
+++ b/cmd/leaderboard.go
@@ -45,7 +45,7 @@ func init() {
 
 func runLeaderBoard(rootOpts *rootOptions) error {
 	ctx := context.Background()
-	c, err := client.New(ctx, rootOpts.tokenPath)
+	c, err := client.New(ctx, rootOpts.token)
 	if err != nil {
 		return err
 	}

--- a/cmd/prs.go
+++ b/cmd/prs.go
@@ -43,7 +43,7 @@ func init() {
 
 func runPRs(rootOpts *rootOptions) error {
 	ctx := context.Background()
-	c, err := client.New(ctx, rootOpts.tokenPath)
+	c, err := client.New(ctx, rootOpts.token)
 	if err != nil {
 		return err
 	}

--- a/cmd/review.go
+++ b/cmd/review.go
@@ -43,7 +43,7 @@ func init() {
 
 func runReviews(rootOpts *rootOptions) error {
 	ctx := context.Background()
-	c, err := client.New(ctx, rootOpts.tokenPath)
+	c, err := client.New(ctx, rootOpts.token)
 	if err != nil {
 		return err
 	}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -52,7 +52,7 @@ func init() {
 
 func runServer(rootOpts *rootOptions) error {
 	ctx := context.Background()
-	c, err := client.New(ctx, rootOpts.tokenPath)
+	c, err := client.New(ctx, rootOpts.token)
 	if err != nil {
 		return err
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -16,8 +16,6 @@ package client
 
 import (
 	"context"
-	"io/ioutil"
-	"strings"
 
 	"github.com/google/go-github/v33/github"
 	"github.com/peterbourgon/diskv"
@@ -31,13 +29,8 @@ type Client struct {
 	GitHubClient *github.Client
 }
 
-func New(ctx context.Context, tokenPath string) (*Client, error) {
-	token, err := ioutil.ReadFile(tokenPath)
-	if err != nil {
-		return nil, err
-	}
-
-	tc := oauth2.NewClient(ctx, oauth2.StaticTokenSource(&oauth2.Token{AccessToken: strings.TrimSpace(string(token))}))
+func New(ctx context.Context, token string) (*Client, error) {
+	tc := oauth2.NewClient(ctx, oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token}))
 	c := github.NewClient(tc)
 
 	dv, err := ghcache.New()


### PR DESCRIPTION
There are now 2 ways to handle giving pullsheet a github token. The original way is to use the `--token-path` flag or `PULLSHEET_TOKEN-PATH` environment variable, which will cause pullsheet to open that file and use its contents as the token. The new way is to use the `PULLSHEET_TOKEN` environment variable, which directly takes the contents of the token and uses that. 