### PR TITLE
Change k8s deployment to use token env var

### DIFF
--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -9,7 +9,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-        go-version: ['1.15.x', '1.16.x']
+        go-version: ['1.16.x']
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -12,7 +12,7 @@ jobs:
     name: Unit Tests
     strategy:
       matrix:
-        go-version: ['1.15.x', '1.16.x']
+        go-version: ['1.16.x']
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,9 @@ COPY pkg /src/pkg/
 RUN go mod download
 RUN go build
 
-# Get token and move binary into /app
+# Setup in /app
 FROM gcr.io/distroless/base AS pullsheet
 WORKDIR /app
 COPY --from=builder /src/pullsheet /app/
-COPY token /app/token
 
-CMD ["/app/pullsheet", "server", "--token-path=./token", "--log-level=info"]
+CMD ["/app/pullsheet", "server", "--log-level=info"]

--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -18,6 +18,11 @@ spec:
         ports:
         - containerPort: 8080
         env:
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: pullsheet-github-token
+              key: token
         - name: PULLSHEET_REPOS
           value: "google/pullsheet"
         - name: PULLSHEET_USERS

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -49,7 +49,7 @@ func New(ctx context.Context, c Config) (*Client, error) {
 	}
 
 	if c.GitHubToken == "" {
-		c.GitHubToken = os.Getenv("GITHUB_TOKEN")
+		c.GitHubToken = strings.TrimSpace(os.Getenv("GITHUB_TOKEN"))
 	}
 
 	if c.GitHubToken == "" {

--- a/pkg/ghcache/ghcache.go
+++ b/pkg/ghcache/ghcache.go
@@ -65,7 +65,7 @@ func PullRequestsListFiles(ctx context.Context, p persist.Cacher, c *github.Clie
 		return val.GHCommitFiles, nil
 	}
 
-	logrus.Debugf("cache miss for %v: %s", key)
+	logrus.Debugf("cache miss for %v", key)
 
 	opts := &github.ListOptions{PerPage: 100}
 	fs := []*github.CommitFile{}
@@ -85,7 +85,6 @@ func PullRequestsListFiles(ctx context.Context, p persist.Cacher, c *github.Clie
 	}
 
 	return fs, p.Set(key, &persist.Blob{GHCommitFiles: fs})
-
 }
 
 func PullRequestsListComments(ctx context.Context, p persist.Cacher, c *github.Client, t time.Time, org string, project string, num int) ([]*github.PullRequestComment, error) {
@@ -96,7 +95,7 @@ func PullRequestsListComments(ctx context.Context, p persist.Cacher, c *github.C
 		return val.GHPullRequestComments, nil
 	}
 
-	logrus.Debugf("cache miss for %v: %s", key)
+	logrus.Debugf("cache miss for %v", key)
 
 	cs := []*github.PullRequestComment{}
 	opts := &github.PullRequestListCommentsOptions{
@@ -128,7 +127,7 @@ func IssuesGet(ctx context.Context, p persist.Cacher, c *github.Client, t time.T
 		return val.GHIssue, nil
 	}
 
-	logrus.Debugf("cache miss for %v: %s", key)
+	logrus.Debugf("cache miss for %v", key)
 
 	i, _, err := c.Issues.Get(ctx, org, project, num)
 	if err != nil {


### PR DESCRIPTION
Updates dockerfile to not copy token into image. Also trims whitespace on the `GITHUB_TOKEN` var that gets read in