### PR TITLE
remove 1.15.x testing

### DIFF
--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -9,7 +9,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-        go-version: ['1.15.x', '1.16.x']
+        go-version: ['1.16.x']
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -12,7 +12,7 @@ jobs:
     name: Unit Tests
     strategy:
       matrix:
-        go-version: ['1.15.x', '1.16.x']
+        go-version: ['1.16.x']
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
Since this project is now using `go 1.16.x` specific functionality, the `1.15.x` CI will always fail, so this PR removes those checks.