### PR TITLE
Switch logging library from logrus to klog.

### DIFF
--- a/cmd/issues.go
+++ b/cmd/issues.go
@@ -20,8 +20,8 @@ import (
 
 	"github.com/gocarina/gocsv"
 	"github.com/google/pullsheet/pkg/summary"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"k8s.io/klog/v2"
 
 	"github.com/google/pullsheet/pkg/client"
 )
@@ -58,7 +58,7 @@ func runIssues(rootOpts *rootOptions) error {
 		return err
 	}
 
-	logrus.Infof("%d bytes of issue output", len(out))
+	klog.Infof("%d bytes of issue output", len(out))
 	fmt.Print(out)
 
 	return nil

--- a/cmd/leaderboard.go
+++ b/cmd/leaderboard.go
@@ -20,8 +20,8 @@ import (
 	"strings"
 
 	"github.com/google/pullsheet/pkg/summary"
+	"k8s.io/klog/v2"
 
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/google/pullsheet/pkg/client"
@@ -80,7 +80,7 @@ func runLeaderBoard(rootOpts *rootOptions) error {
 		return err
 	}
 
-	logrus.Infof("%d bytes of issue-comments output", len(out))
+	klog.Infof("%d bytes of issue-comments output", len(out))
 	fmt.Print(out)
 
 	return nil

--- a/cmd/prs.go
+++ b/cmd/prs.go
@@ -20,8 +20,8 @@ import (
 
 	"github.com/gocarina/gocsv"
 	"github.com/google/pullsheet/pkg/summary"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"k8s.io/klog/v2"
 
 	"github.com/google/pullsheet/pkg/client"
 )
@@ -58,7 +58,7 @@ func runPRs(rootOpts *rootOptions) error {
 		return err
 	}
 
-	logrus.Infof("%d bytes of prs output", len(out))
+	klog.Infof("%d bytes of prs output", len(out))
 	fmt.Print(out)
 
 	return nil

--- a/cmd/review.go
+++ b/cmd/review.go
@@ -20,8 +20,8 @@ import (
 
 	"github.com/gocarina/gocsv"
 	"github.com/google/pullsheet/pkg/summary"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"k8s.io/klog/v2"
 
 	"github.com/google/pullsheet/pkg/client"
 )
@@ -58,7 +58,7 @@ func runReviews(rootOpts *rootOptions) error {
 		return err
 	}
 
-	logrus.Infof("%d bytes of reviews output", len(out))
+	klog.Infof("%d bytes of reviews output", len(out))
 	fmt.Print(out)
 
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,9 @@ require (
 	github.com/google/triage-party v0.0.0-20210325043323-fc6840b93022
 	github.com/karrick/tparse v2.4.2+incompatible
 	github.com/pkg/errors v0.9.1
-	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/viper v1.7.1
 	golang.org/x/oauth2 v0.0.0-20210323180902-22b0adad7558
+	k8s.io/klog v1.0.0 // indirect
+	k8s.io/klog/v2 v2.0.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -269,9 +269,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/sirupsen/logrus v1.2.0 h1:juTguoYk5qI21pwyTXY3B3Y5cOTH3ZUyZCg1v/mihuo=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
-github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
-github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
@@ -602,6 +601,8 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
+k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
+k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog/v2 v2.0.0 h1:Foj74zO6RbjjP4hBEKjnYtjjAhGg4jNynUdYF6fJrok=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=

--- a/pkg/ghcache/ghcache.go
+++ b/pkg/ghcache/ghcache.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/google/go-github/v33/github"
 	"github.com/google/triage-party/pkg/persist"
-	"github.com/sirupsen/logrus"
+	"k8s.io/klog/v2"
 )
 
 func PullRequestsGet(ctx context.Context, p persist.Cacher, c *github.Client, t time.Time, org string, project string, num int) (*github.PullRequest, error) {
@@ -33,7 +33,7 @@ func PullRequestsGet(ctx context.Context, p persist.Cacher, c *github.Client, t 
 	}
 
 	if val == nil {
-		logrus.Debugf("cache miss for %v", key)
+		klog.Infof("cache miss for %v", key)
 		pr, _, err := c.PullRequests.Get(ctx, org, project, num)
 		if err != nil {
 			return nil, fmt.Errorf("get: %v", err)
@@ -41,7 +41,7 @@ func PullRequestsGet(ctx context.Context, p persist.Cacher, c *github.Client, t 
 		return pr, p.Set(key, &persist.Blob{GHPullRequest: pr})
 	}
 
-	logrus.Debugf("cache hit: %v", key)
+	klog.Infof("cache hit: %v", key)
 	return val.GHPullRequest, nil
 }
 
@@ -53,7 +53,7 @@ func PullRequestsListFiles(ctx context.Context, p persist.Cacher, c *github.Clie
 		return val.GHCommitFiles, nil
 	}
 
-	logrus.Debugf("cache miss for %v", key)
+	klog.Infof("cache miss for %v", key)
 
 	opts := &github.ListOptions{PerPage: 100}
 	fs := []*github.CommitFile{}
@@ -83,7 +83,7 @@ func PullRequestsListComments(ctx context.Context, p persist.Cacher, c *github.C
 		return val.GHPullRequestComments, nil
 	}
 
-	logrus.Debugf("cache miss for %v", key)
+	klog.Infof("cache miss for %v", key)
 
 	cs := []*github.PullRequestComment{}
 	opts := &github.PullRequestListCommentsOptions{
@@ -115,7 +115,7 @@ func IssuesGet(ctx context.Context, p persist.Cacher, c *github.Client, t time.T
 		return val.GHIssue, nil
 	}
 
-	logrus.Debugf("cache miss for %v", key)
+	klog.Infof("cache miss for %v", key)
 
 	i, _, err := c.Issues.Get(ctx, org, project, num)
 	if err != nil {

--- a/pkg/repo/files.go
+++ b/pkg/repo/files.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/google/go-github/v33/github"
-	"github.com/sirupsen/logrus"
+	"k8s.io/klog/v2"
 
 	"github.com/google/pullsheet/pkg/client"
 	"github.com/google/pullsheet/pkg/ghcache"
@@ -29,22 +29,22 @@ import (
 
 // FilteredFiles returns a list of commit files that matter
 func FilteredFiles(ctx context.Context, c *client.Client, t time.Time, org string, project string, num int) ([]*github.CommitFile, error) {
-	logrus.Infof("Fetching file list for #%d", num)
+	klog.Infof("Fetching file list for #%d", num)
 
 	changed, err := ghcache.PullRequestsListFiles(ctx, c.Cache, c.GitHubClient, t, org, project, num)
 	if err != nil {
 		return nil, err
 	}
 
-	logrus.Infof("%s/%s #%d had %d changed files", org, project, num, len(changed))
+	klog.Infof("%s/%s #%d had %d changed files", org, project, num, len(changed))
 
 	files := []*github.CommitFile{}
 	for _, cf := range changed {
 		if ignorePathRe.MatchString(cf.GetFilename()) {
-			logrus.Infof("ignoring %s", cf.GetFilename())
+			klog.Infof("ignoring %s", cf.GetFilename())
 			continue
 		}
-		logrus.Errorf("#%d changed: %s", num, cf.GetFilename())
+		klog.Errorf("#%d changed: %s", num, cf.GetFilename())
 
 		files = append(files, cf)
 	}
@@ -63,7 +63,7 @@ func prType(files []github.CommitFile) string {
 			if result == "" {
 				result = "docs"
 			}
-			logrus.Infof("%s: %s", f, result)
+			klog.Infof("%s: %s", f, result)
 			continue
 		}
 
@@ -71,7 +71,7 @@ func prType(files []github.CommitFile) string {
 			if result == "" {
 				result = "tests"
 			}
-			logrus.Infof("%s: %s", f, result)
+			klog.Infof("%s: %s", f, result)
 			continue
 		}
 
@@ -87,7 +87,7 @@ func prType(files []github.CommitFile) string {
 			result = "frontend"
 		}
 
-		logrus.Infof("%s (ext=%s): %s", f, ext, result)
+		klog.Infof("%s (ext=%s): %s", f, ext, result)
 	}
 
 	if result == "" {

--- a/pkg/repo/issue_comments.go
+++ b/pkg/repo/issue_comments.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sirupsen/logrus"
+	"k8s.io/klog/v2"
 
 	"github.com/google/pullsheet/pkg/client"
 	"github.com/google/pullsheet/pkg/ghcache"
@@ -46,7 +46,7 @@ func IssueComments(ctx context.Context, c *client.Client, org string, project st
 		return nil, fmt.Errorf("issues: %v", err)
 	}
 
-	logrus.Infof("found %d issues to check comments on", len(is))
+	klog.Infof("found %d issues to check comments on", len(is))
 	reviews := []*CommentSummary{}
 
 	matchUser := map[string]bool{}
@@ -91,7 +91,7 @@ func IssueComments(ctx context.Context, c *client.Client, org string, project st
 
 			body := strings.TrimSpace(i.GetBody())
 			if (strings.HasPrefix(body, "/") || strings.HasPrefix(body, "cc")) && len(body) < 64 {
-				logrus.Infof("ignoring tag comment: %q", body)
+				klog.Infof("ignoring tag comment: %q", body)
 				continue
 			}
 
@@ -111,7 +111,7 @@ func IssueComments(ctx context.Context, c *client.Client, org string, project st
 			iMap[commenter].Comments++
 			iMap[commenter].Date = c.CreatedAt.Format(dateForm)
 			iMap[commenter].Words += wordCount
-			logrus.Infof("%d word comment by %s: %q for %s/%s #%d", wordCount, commenter, strings.TrimSpace(c.GetBody()), org, project, i.GetNumber())
+			klog.Infof("%d word comment by %s: %q for %s/%s #%d", wordCount, commenter, strings.TrimSpace(c.GetBody()), org, project, i.GetNumber())
 		}
 
 		for _, rs := range iMap {

--- a/pkg/repo/review_comments.go
+++ b/pkg/repo/review_comments.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/blevesearch/segment"
 	"github.com/google/go-github/v33/github"
-	"github.com/sirupsen/logrus"
+	"k8s.io/klog/v2"
 
 	"github.com/google/pullsheet/pkg/client"
 	"github.com/google/pullsheet/pkg/ghcache"
@@ -60,7 +60,7 @@ func MergedReviews(ctx context.Context, c *client.Client, org string, project st
 		return nil, fmt.Errorf("pulls: %v", err)
 	}
 
-	logrus.Infof("found %d PR's in %s/%s to find reviews for", len(prs), org, project)
+	klog.Infof("found %d PR's in %s/%s to find reviews for", len(prs), org, project)
 	reviews := []*ReviewSummary{}
 
 	matchUser := map[string]bool{}
@@ -100,7 +100,7 @@ func MergedReviews(ctx context.Context, c *client.Client, org string, project st
 
 			body := strings.TrimSpace(i.GetBody())
 			if (strings.HasPrefix(body, "/") || strings.HasPrefix(body, "cc")) && len(body) < 64 {
-				logrus.Infof("ignoring tag comment in %s: %q", i.GetHTMLURL(), body)
+				klog.Infof("ignoring tag comment in %s: %q", i.GetHTMLURL(), body)
 				continue
 			}
 
@@ -144,7 +144,7 @@ func MergedReviews(ctx context.Context, c *client.Client, org string, project st
 
 			prMap[c.Author].Date = c.CreatedAt.Format(dateForm)
 			prMap[c.Author].Words += wordCount
-			logrus.Infof("%d word comment by %s: %q for %s/%s #%d", wordCount, c.Author, strings.TrimSpace(c.Body), org, project, pr.GetNumber())
+			klog.Infof("%d word comment by %s: %q for %s/%s #%d", wordCount, c.Author, strings.TrimSpace(c.Body), org, project, pr.GetNumber())
 		}
 
 		for _, rs := range prMap {

--- a/pkg/server/job/job.go
+++ b/pkg/server/job/job.go
@@ -19,7 +19,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/sirupsen/logrus"
+	"k8s.io/klog/v2"
 
 	"github.com/google/pullsheet/pkg/client"
 	"github.com/google/pullsheet/pkg/leaderboard"
@@ -69,7 +69,7 @@ func (j *Job) Render() (string, error) {
 func (j *Job) Update(ctx context.Context, cl *client.Client) {
 	err := j.u.updateData(ctx, cl, j.opts)
 	if err != nil {
-		logrus.Errorf("Failed to update job: %d", err)
+		klog.Errorf("Failed to update job: %d", err)
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -26,7 +26,7 @@ import (
 	"github.com/google/pullsheet/pkg/server/job"
 	"github.com/google/pullsheet/pkg/server/site"
 	"github.com/karrick/tparse"
-	"github.com/sirupsen/logrus"
+	"k8s.io/klog"
 )
 
 const dateForm = "2006-01-02"
@@ -58,7 +58,7 @@ func (s *Server) Home() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		res, err := site.Home(s.jobs)
 		if err != nil {
-			logrus.Errorf("rendering home page: %d", err)
+			klog.Errorf("rendering home page: %d", err)
 		}
 		fmt.Fprint(w, res)
 	}
@@ -74,7 +74,7 @@ func (s *Server) Job() http.HandlerFunc {
 		}
 		idx, err := strconv.Atoi(slug)
 		if err != nil {
-			logrus.Errorf("getting job index: %d", err)
+			klog.Errorf("getting job index: %d", err)
 		}
 		if idx >= len(s.jobs) {
 			idx = 0
@@ -83,7 +83,7 @@ func (s *Server) Job() http.HandlerFunc {
 		// Render job from index number
 		res, err := s.jobs[idx].Render()
 		if err != nil {
-			logrus.Errorf("rendering home page: %d", err)
+			klog.Errorf("rendering home page: %d", err)
 		}
 		fmt.Fprint(w, res)
 	}
@@ -109,11 +109,11 @@ func (s *Server) NewJob() http.HandlerFunc {
 
 			sinceParsed, err := tparse.ParseNow(dateForm, since)
 			if err != nil {
-				logrus.Errorf("Parsing from: %d", err)
+				klog.Errorf("Parsing from: %d", err)
 			}
 			untilParsed, err := tparse.ParseNow(dateForm, until)
 			if err != nil {
-				logrus.Errorf("Parsing from: %d", err)
+				klog.Errorf("Parsing from: %d", err)
 			}
 
 			s.AddJob(context.Background(), job.New(&job.Opts{
@@ -147,10 +147,10 @@ func (s *Server) Healthz() http.HandlerFunc {
 // Threadz returns a threadz page
 func (s *Server) Threadz() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		logrus.Infof("GET %s: %v", r.URL.Path, r.Header)
+		klog.Infof("GET %s: %v", r.URL.Path, r.Header)
 		w.WriteHeader(http.StatusOK)
 		if _, err := w.Write(stack()); err != nil {
-			logrus.Errorf("writing threadz response: %d", err)
+			klog.Errorf("writing threadz response: %d", err)
 		}
 	}
 }

--- a/pkg/summary/summary.go
+++ b/pkg/summary/summary.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	"github.com/google/go-github/v33/github"
-	"github.com/sirupsen/logrus"
+	"k8s.io/klog"
 
 	"github.com/google/pullsheet/pkg/client"
 	"github.com/google/pullsheet/pkg/repo"
@@ -42,7 +42,7 @@ func Pulls(ctx context.Context, c *client.Client, repos []string, users []string
 			if err != nil {
 				return nil, fmt.Errorf("filtered files: %v", err)
 			}
-			logrus.Errorf("%s files: %v", pr, files)
+			klog.Errorf("%s files: %v", pr, files)
 
 			prFiles[pr] = []github.CommitFile{}
 


### PR DESCRIPTION
fixes #35.

Previously, the primary logging library was logrus. However, triage-party (one of our dependencies) used klog. Since this is more standard for kubernetes, this switches us to klog. Some minor behavior has changed, for example the few lines using `logrus.Debugf` have been replaced with `klog.Infof`.

Note: We still implicitly depend on logrus through `github.com/spf13/viper`. In my use case, no log messages were produced by logrus though. We likely could remove viper since its only purpose is allowing variables to be defaulted to environment variables (which is a very limited usage).