### PR TITLE
Changes to enable JSON output | FIX for ISSUE_5

### DIFF
--- a/cmd/issues-comments.go
+++ b/cmd/issues-comments.go
@@ -16,9 +16,8 @@ package cmd
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/gocarina/gocsv"
+	"github.com/google/pullsheet/pkg/print"
 	"github.com/google/pullsheet/pkg/summary"
 	"github.com/spf13/cobra"
 
@@ -52,11 +51,11 @@ func runIssueComments(rootOpts *rootOptions) error {
 		return err
 	}
 
-	out, err := gocsv.MarshalString(&data)
+	err = print.Print(data, rootOpts.out)
+
 	if err != nil {
 		return err
 	}
 
-	fmt.Print(out)
 	return nil
 }

--- a/cmd/issues.go
+++ b/cmd/issues.go
@@ -16,12 +16,10 @@ package cmd
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/gocarina/gocsv"
+	"github.com/google/pullsheet/pkg/print"
 	"github.com/google/pullsheet/pkg/summary"
 	"github.com/spf13/cobra"
-	"k8s.io/klog/v2"
 
 	"github.com/google/pullsheet/pkg/client"
 )
@@ -53,13 +51,11 @@ func runIssues(rootOpts *rootOptions) error {
 		return err
 	}
 
-	out, err := gocsv.MarshalString(&data)
+	err = print.Print(data, rootOpts.out)
+
 	if err != nil {
 		return err
 	}
-
-	klog.Infof("%d bytes of issue output", len(out))
-	fmt.Print(out)
 
 	return nil
 }

--- a/cmd/prs.go
+++ b/cmd/prs.go
@@ -16,12 +16,10 @@ package cmd
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/gocarina/gocsv"
+	"github.com/google/pullsheet/pkg/print"
 	"github.com/google/pullsheet/pkg/summary"
 	"github.com/spf13/cobra"
-	"k8s.io/klog/v2"
 
 	"github.com/google/pullsheet/pkg/client"
 )
@@ -53,13 +51,11 @@ func runPRs(rootOpts *rootOptions) error {
 		return err
 	}
 
-	out, err := gocsv.MarshalString(&data)
+	err = print.Print(data, rootOpts.out)
+
 	if err != nil {
 		return err
 	}
-
-	klog.Infof("%d bytes of prs output", len(out))
-	fmt.Print(out)
 
 	return nil
 }

--- a/cmd/review.go
+++ b/cmd/review.go
@@ -16,14 +16,12 @@ package cmd
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/gocarina/gocsv"
 	"github.com/google/pullsheet/pkg/summary"
 	"github.com/spf13/cobra"
-	"k8s.io/klog/v2"
 
 	"github.com/google/pullsheet/pkg/client"
+	"github.com/google/pullsheet/pkg/print"
 )
 
 // reviewsCmd represents the subcommand for `pullsheet reviews`
@@ -53,13 +51,11 @@ func runReviews(rootOpts *rootOptions) error {
 		return err
 	}
 
-	out, err := gocsv.MarshalString(&data)
+	err = print.Print(data, rootOpts.out)
+
 	if err != nil {
 		return err
 	}
-
-	klog.Infof("%d bytes of reviews output", len(out))
-	fmt.Print(out)
 
 	return nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -141,7 +141,7 @@ func initRootOpts() error {
 	}
 
 	if rootOpts.out != "JSON" && rootOpts.out != "CSV" {
-		return fmt.Errorf("Invalid out parameter %s. Must be JSON or CSV", rootOpts.out)
+		return fmt.Errorf("invalid out parameter %s. Must be JSON or CSV", rootOpts.out)
 	}
 
 	// Set options. viper will prioritize flags over env variables

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -117,7 +117,7 @@ func init() {
 		&rootOpts.out,
 		"out",
 		"CSV",
-		"Output type - CSV/JSON",
+		"Output type - CSV/JSON. Default is CSV",
 	)
 
 	// Set up viper flag handling
@@ -141,7 +141,7 @@ func initRootOpts() error {
 	}
 
 	if rootOpts.out != "JSON" && rootOpts.out != "CSV" {
-		return fmt.Errorf("Invalid out parameter %s. Enter JSON/CSV", rootOpts.out)
+		return fmt.Errorf("Invalid out parameter %s. Must be JSON or CSV", rootOpts.out)
 	}
 
 	// Set options. viper will prioritize flags over env variables

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"flag"
+	"fmt"
 	"time"
 
 	"github.com/karrick/tparse"
@@ -46,6 +47,7 @@ type rootOptions struct {
 	title       string
 	tokenPath   string
 	branches    []string
+	out         string
 }
 
 var rootOpts = &rootOptions{}
@@ -111,6 +113,13 @@ func init() {
 		"GitHub token path",
 	)
 
+	rootCmd.PersistentFlags().StringVar(
+		&rootOpts.out,
+		"out",
+		"CSV",
+		"Output type - CSV/JSON",
+	)
+
 	// Set up viper flag handling
 	if err := viper.BindPFlags(rootCmd.PersistentFlags()); err != nil {
 		panic(err)
@@ -123,12 +132,16 @@ func initRootOpts() error {
 	// Set up viper environment variable handling
 	viper.SetEnvPrefix("pullsheet")
 	envKeys := []string{
-		"repos", "branches", "users", "since", "until", "title", "token-path",
+		"repos", "branches", "users", "since", "until", "title", "token-path", "out",
 	}
 	for _, key := range envKeys {
 		if err := viper.BindEnv(key); err != nil {
 			return err
 		}
+	}
+
+	if rootOpts.out != "JSON" && rootOpts.out != "CSV" {
+		return fmt.Errorf("Invalid out parameter %s. Enter JSON/CSV", rootOpts.out)
 	}
 
 	// Set options. viper will prioritize flags over env variables
@@ -139,7 +152,7 @@ func initRootOpts() error {
 	rootOpts.until = viper.GetString("until")
 	rootOpts.title = viper.GetString("title")
 	rootOpts.tokenPath = viper.GetString("token-path")
-
+	rootOpts.out = viper.GetString("out")
 	return nil
 }
 

--- a/pkg/print/print.go
+++ b/pkg/print/print.go
@@ -22,18 +22,18 @@ import (
 	"k8s.io/klog"
 )
 
-//This method prints the values in "data" interface to standatrd output in the format specified by "out_type", either JSON/CSV
-func Print(data interface{}, out_type string) error {
+// This method prints the values in "data" interface to standatrd output in the format specified by "out_type", either JSON/CSV
+func Print(data interface{}, outType string) error {
 	var (
 		err error
 		out string
 	)
 
-	if out_type == "JSON" {
+	if outType == "JSON" {
 		var jsonvar []byte
 		jsonvar, err = json.Marshal(data)
 		out = string(jsonvar)
-	} else if out_type == "CSV" {
+	} else if outType == "CSV" {
 		out, err = gocsv.MarshalString(data)
 	}
 

--- a/pkg/print/print.go
+++ b/pkg/print/print.go
@@ -1,0 +1,46 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package print
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/gocarina/gocsv"
+	"k8s.io/klog"
+)
+
+//This method prints the values in "data" interface to standatrd output in the format specified by "out_type", either JSON/CSV
+func Print(data interface{}, out_type string) error {
+	var er error
+	var out string
+
+	if out_type == "JSON" {
+		var jsonvar []byte
+		jsonvar, er = json.Marshal(data)
+		out = string(jsonvar)
+	} else if out_type == "CSV" {
+		out, er = gocsv.MarshalString(data)
+	}
+
+	if er != nil {
+		return er
+	}
+
+	klog.Infof("%d bytes of reviews output", len(out))
+	fmt.Print(out)
+
+	return nil
+}

--- a/pkg/print/print.go
+++ b/pkg/print/print.go
@@ -24,19 +24,21 @@ import (
 
 //This method prints the values in "data" interface to standatrd output in the format specified by "out_type", either JSON/CSV
 func Print(data interface{}, out_type string) error {
-	var er error
-	var out string
+	var (
+		err error
+		out string
+	)
 
 	if out_type == "JSON" {
 		var jsonvar []byte
-		jsonvar, er = json.Marshal(data)
+		jsonvar, err = json.Marshal(data)
 		out = string(jsonvar)
 	} else if out_type == "CSV" {
-		out, er = gocsv.MarshalString(data)
+		out, err = gocsv.MarshalString(data)
 	}
 
-	if er != nil {
-		return er
+	if err != nil {
+		return err
 	}
 
 	klog.Infof("%d bytes of reviews output", len(out))


### PR DESCRIPTION
@tstromberg @cpanato 
I have added a new "out" flag
Usage: --out JSON or --out CSV
default: CSV

I have noticed that in cmd/review, cmd/prs, cmd/issues, cmd/issues-comments files, we are calling the Marshall function. So instead of redundantly checking for JSON/CSV output in each of these files, I have created a print package under pkg/print where we handle whether to print JSON/CSV. We can now call this function from all of those folders mentioned above. 

Example: 
go run pullsheet.go prs --repos kubernetes/minikube --since 2021-06-10 --out JSON --token-path <PathToMyToken> > prs.json