### PR TITLE
Add option to include bots through `--include-bots` flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,6 +48,7 @@ type rootOptions struct {
 	tokenPath   string
 	branches    []string
 	out         string
+	includeBots bool // if true will include bots in the metrics
 }
 
 var rootOpts = &rootOptions{}
@@ -97,6 +98,14 @@ func init() {
 		"until",
 		"now",
 		"when to query till (date or duration)",
+	)
+
+	rootCmd.PersistentFlags().BoolVarP(
+		&rootOpts.includeBots,
+		"include-bots",
+		"",
+		false,
+		"include bots in the stats",
 	)
 
 	rootCmd.PersistentFlags().StringVar(
@@ -153,6 +162,7 @@ func initRootOpts() error {
 	rootOpts.title = viper.GetString("title")
 	rootOpts.tokenPath = viper.GetString("token-path")
 	rootOpts.out = viper.GetString("out")
+	rootOpts.includeBots = viper.GetBool("include-bots")
 	return nil
 }
 

--- a/pkg/repo/review_comments.go
+++ b/pkg/repo/review_comments.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/blevesearch/segment"
 	"github.com/google/go-github/v33/github"
+	"github.com/spf13/viper"
 	"k8s.io/klog/v2"
 
 	"github.com/google/pullsheet/pkg/client"
@@ -173,6 +174,10 @@ func wordCount(s string) int {
 }
 
 func isBot(u *github.User) bool {
+	includeBots := viper.GetBool("include-bots")
+	if includeBots == true {
+		return false
+	}
 	if u.GetType() == "bot" {
 		return true
 	}

--- a/pkg/repo/review_comments.go
+++ b/pkg/repo/review_comments.go
@@ -175,7 +175,7 @@ func wordCount(s string) int {
 
 func isBot(u *github.User) bool {
 	includeBots := viper.GetBool("include-bots")
-	if includeBots == true {
+	if includeBots {
 		return false
 	}
 	if u.GetType() == "bot" {


### PR DESCRIPTION
after this PR you can include bots with --include-bots

for example: 

```
go run pullsheet.go prs --include-bots --token-path ~/token.txt --repos kubernetes/minikube,medyagh/gopogh,GoogleContainerTools/gcp-auth-webhook,GoogleContainerTools/minikube-image-benchmark --since 2021-04-01 --until 2021-08-23 --logtostderr=false  >> ~/Desktop/perf_prs.csv
```