### PR TITLE
Allow disabling caching for leaderboard pages `--no-caching`

### DIFF
--- a/cmd/leaderboard.go
+++ b/cmd/leaderboard.go
@@ -39,7 +39,15 @@ var leaderBoardCmd = &cobra.Command{
 	},
 }
 
+var disableCaching bool
+
 func init() {
+	leaderBoardCmd.Flags().BoolVar(
+		&disableCaching,
+		"no-caching",
+		false,
+		"Disable caching on resulting HTML files")
+
 	rootCmd.AddCommand(leaderBoardCmd)
 }
 
@@ -76,9 +84,10 @@ func runLeaderBoard(rootOpts *rootOptions) error {
 	}
 
 	out, err := leaderboard.Render(leaderboard.Options{
-		Title: title,
-		Since: rootOpts.sinceParsed,
-		Until: rootOpts.untilParsed,
+		Title:          title,
+		Since:          rootOpts.sinceParsed,
+		Until:          rootOpts.untilParsed,
+		DisableCaching: disableCaching,
 	}, rootOpts.users, prs, reviews, issues, comments)
 	if err != nil {
 		return err

--- a/cmd/leaderboard.go
+++ b/cmd/leaderboard.go
@@ -75,7 +75,11 @@ func runLeaderBoard(rootOpts *rootOptions) error {
 		title = strings.Join(rootOpts.repos, ", ")
 	}
 
-	out, err := leaderboard.Render(title, rootOpts.sinceParsed, rootOpts.untilParsed, rootOpts.users, prs, reviews, issues, comments)
+	out, err := leaderboard.Render(leaderboard.Options{
+		Title: title,
+		Since: rootOpts.sinceParsed,
+		Until: rootOpts.untilParsed,
+	}, rootOpts.users, prs, reviews, issues, comments)
 	if err != nil {
 		return err
 	}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -46,6 +46,11 @@ func init() {
 		"port",
 		8080,
 		"Port for server to listen on")
+	serverCmd.Flags().BoolVar(
+		&disableCaching,
+		"no-caching",
+		false,
+		"Disable caching on resulting HTML files")
 
 	rootCmd.AddCommand(serverCmd)
 }
@@ -60,12 +65,13 @@ func runServer(rootOpts *rootOptions) error {
 	// setup initial job
 	j := job.New(
 		&job.Opts{
-			Repos:    rootOpts.repos,
-			Users:    rootOpts.users,
-			Branches: rootOpts.branches,
-			Since:    rootOpts.sinceParsed,
-			Until:    rootOpts.untilParsed,
-			Title:    rootOpts.title,
+			Repos:          rootOpts.repos,
+			Users:          rootOpts.users,
+			Branches:       rootOpts.branches,
+			Since:          rootOpts.sinceParsed,
+			Until:          rootOpts.untilParsed,
+			Title:          rootOpts.title,
+			DisableCaching: disableCaching,
 		})
 
 	s := server.New(ctx, c, j)

--- a/pkg/leaderboard/leaderboard.go
+++ b/pkg/leaderboard/leaderboard.go
@@ -32,6 +32,13 @@ const dateForm = "2006-01-02"
 // TopX is how many items to include in graphs
 var TopX = 15
 
+// Options to use for rendering the leaderboard
+type Options struct {
+	Title string
+	Since time.Time
+	Until time.Time
+}
+
 type category struct {
 	Title  string
 	Charts []chart
@@ -51,7 +58,7 @@ type item struct {
 }
 
 // Render returns an HTML formatted leaderboard page
-func Render(title string, since time.Time, until time.Time, users []string, prs []*repo.PRSummary, reviews []*repo.ReviewSummary, issues []*repo.IssueSummary, comments []*repo.CommentSummary) (string, error) {
+func Render(options Options, users []string, prs []*repo.PRSummary, reviews []*repo.ReviewSummary, issues []*repo.IssueSummary, comments []*repo.CommentSummary) (string, error) {
 	funcMap := template.FuncMap{}
 	tmpl, err := template.New("LeaderBoard").Funcs(funcMap).Parse(leaderboardTmpl)
 	if err != nil {
@@ -65,9 +72,9 @@ func Render(title string, since time.Time, until time.Time, users []string, prs 
 		Command    string
 		Categories []category
 	}{
-		Title:   title,
-		From:    since.Format(dateForm),
-		Until:   until.Format(dateForm),
+		Title:   options.Title,
+		From:    options.Since.Format(dateForm),
+		Until:   options.Until.Format(dateForm),
 		Command: filepath.Base(os.Args[0]) + " " + strings.Join(os.Args[1:], " "),
 		Categories: []category{
 			{

--- a/pkg/leaderboard/leaderboard.go
+++ b/pkg/leaderboard/leaderboard.go
@@ -34,9 +34,10 @@ var TopX = 15
 
 // Options to use for rendering the leaderboard
 type Options struct {
-	Title string
-	Since time.Time
-	Until time.Time
+	Title          string
+	Since          time.Time
+	Until          time.Time
+	DisableCaching bool
 }
 
 type category struct {
@@ -66,16 +67,18 @@ func Render(options Options, users []string, prs []*repo.PRSummary, reviews []*r
 	}
 
 	data := struct {
-		Title      string
-		From       string
-		Until      string
-		Command    string
-		Categories []category
+		Title          string
+		From           string
+		Until          string
+		DisableCaching bool
+		Command        string
+		Categories     []category
 	}{
-		Title:   options.Title,
-		From:    options.Since.Format(dateForm),
-		Until:   options.Until.Format(dateForm),
-		Command: filepath.Base(os.Args[0]) + " " + strings.Join(os.Args[1:], " "),
+		Title:          options.Title,
+		From:           options.Since.Format(dateForm),
+		Until:          options.Until.Format(dateForm),
+		DisableCaching: options.DisableCaching,
+		Command:        filepath.Base(os.Args[0]) + " " + strings.Join(os.Args[1:], " "),
 		Categories: []category{
 			{
 				Title: "Reviewers",

--- a/pkg/leaderboard/leaderboard_templage.go
+++ b/pkg/leaderboard/leaderboard_templage.go
@@ -17,6 +17,11 @@ package leaderboard
 const leaderboardTmpl = `<html>
 <head>
     <title>{{ .Title }} - Leaderboard</title>
+		{{ if .DisableCaching }}
+    <meta http-equiv="CacheControl" content="no-cache, no-store, must-revalidate"/>
+    <meta http-equiv="Pragma" content="no-cache"/>
+    <meta http-equiv="Expires" content="0"/>
+		{{ end }}
     <link rel="preconnect" href="https://fonts.gstatic.com">
     <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600;700&display=swap" rel="stylesheet">
     <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>

--- a/pkg/server/job/job.go
+++ b/pkg/server/job/job.go
@@ -58,7 +58,11 @@ func (j *Job) Render() (string, error) {
 		comments: j.u.getComments(),
 	}
 
-	result, err := leaderboard.Render(j.opts.Title, j.opts.Since, j.opts.Until, j.opts.Users, d.prs, d.reviews, d.issues, d.comments)
+	result, err := leaderboard.Render(leaderboard.Options{
+		Title: j.opts.Title,
+		Since: j.opts.Since,
+		Until: j.opts.Until,
+	}, j.opts.Users, d.prs, d.reviews, d.issues, d.comments)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/server/job/job.go
+++ b/pkg/server/job/job.go
@@ -32,12 +32,13 @@ type Job struct {
 
 // Options related to the Job
 type Opts struct {
-	Repos    []string
-	Branches []string
-	Users    []string
-	Since    time.Time
-	Until    time.Time
-	Title    string
+	Repos          []string
+	Branches       []string
+	Users          []string
+	Since          time.Time
+	Until          time.Time
+	Title          string
+	DisableCaching bool
 }
 
 func New(opts *Opts) *Job {
@@ -59,9 +60,10 @@ func (j *Job) Render() (string, error) {
 	}
 
 	result, err := leaderboard.Render(leaderboard.Options{
-		Title: j.opts.Title,
-		Since: j.opts.Since,
-		Until: j.opts.Until,
+		Title:          j.opts.Title,
+		Since:          j.opts.Since,
+		Until:          j.opts.Until,
+		DisableCaching: j.opts.DisableCaching,
 	}, j.opts.Users, d.prs, d.reviews, d.issues, d.comments)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
This adds the --no-caching flag to disable caching of the HTML files produced.

Excluding "--no-caching":
```
<html>
<head>
    <title>kubernetes/minikube - Leaderboard</title>
                
    <link rel="preconnect" href="https://fonts.gstatic.com">
    <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600;700&display=swap" rel="stylesheet">
    <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
    <script type="text/javascript">
...
```

Including "--no-caching":
```
<html>
<head>
    <title>kubernetes/minikube - Leaderboard</title>
                
    <meta http-equiv="CacheControl" content="no-cache, no-store, must-revalidate"/>
    <meta http-equiv="Pragma" content="no-cache"/>
    <meta http-equiv="Expires" content="0"/>
                
    <link rel="preconnect" href="https://fonts.gstatic.com">
    <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600;700&display=swap" rel="stylesheet">
    <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
    <script type="text/javascript">
...
```