### PR TITLE
add JSON support for the leaderboard command

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,8 +12,9 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v3
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.37.1
+          version: v1.46.2

--- a/cmd/leaderboard.go
+++ b/cmd/leaderboard.go
@@ -221,5 +221,5 @@ func writeToJSON(d *data) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(jsonOutput, b, 0644)
+	return os.WriteFile(jsonOutput, b, 0o644)
 }

--- a/cmd/leaderboard.go
+++ b/cmd/leaderboard.go
@@ -16,10 +16,15 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
+	"time"
 
+	"github.com/google/pullsheet/pkg/repo"
 	"github.com/google/pullsheet/pkg/summary"
+	"github.com/karrick/tparse"
 	"k8s.io/klog/v2"
 
 	"github.com/spf13/cobra"
@@ -28,18 +33,34 @@ import (
 	"github.com/google/pullsheet/pkg/leaderboard"
 )
 
-// leaderBoardCmd represents the subcommand for `pullsheet leaderboard`
-var leaderBoardCmd = &cobra.Command{
-	Use:           "leaderboard",
-	Short:         "Generate leaderboard data",
-	SilenceUsage:  true,
-	SilenceErrors: true,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return runLeaderBoard(rootOpts)
-	},
-}
+var (
+	// leaderBoardCmd represents the subcommand for `pullsheet leaderboard`
+	leaderBoardCmd = &cobra.Command{
+		Use:           "leaderboard",
+		Short:         "Generate leaderboard data",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runLeaderBoard(rootOpts)
+		},
+	}
 
-var disableCaching bool
+	disableCaching     bool
+	hideCommand        bool
+	jsonFiles          []string
+	jsonOutput         string
+	sinceDisplay       string
+	untilDisplay       string
+	sinceParsedDisplay time.Time
+	untilParsedDisplay time.Time
+)
+
+type data struct {
+	PRs      []*repo.PRSummary
+	Reviews  []*repo.ReviewSummary
+	Issues   []*repo.IssueSummary
+	Comments []*repo.CommentSummary
+}
 
 func init() {
 	leaderBoardCmd.Flags().BoolVar(
@@ -48,33 +69,77 @@ func init() {
 		false,
 		"Disable caching on resulting HTML files")
 
+	leaderBoardCmd.Flags().BoolVar(
+		&hideCommand,
+		"hide-command",
+		false,
+		"Hide the command-line args in the HTML")
+
+	leaderBoardCmd.Flags().StringSliceVar(
+		&jsonFiles,
+		"json-files",
+		[]string{},
+		"List of JSON files to append to the results",
+	)
+
+	leaderBoardCmd.Flags().StringVar(
+		&jsonOutput,
+		"json-output",
+		"",
+		"Filepath to write the resulting JSON to, will omit if none specified",
+	)
+
+	leaderBoardCmd.Flags().StringVar(
+		&sinceDisplay,
+		"since-display",
+		"",
+		"This overrides the since date displayed on the leaderboard, primary used if appending past JSON files",
+	)
+
+	leaderBoardCmd.Flags().StringVar(
+		&untilDisplay,
+		"until-display",
+		"",
+		"This overrides the until date displayed on the leaderboard, primary used if appending past JSON files",
+	)
+
 	rootCmd.AddCommand(leaderBoardCmd)
 }
 
+func stringToTime(s string, root time.Time) (time.Time, error) {
+	if s == "" {
+		return root, nil
+	}
+	parsed, err := tparse.ParseNow(dateForm, s)
+	if err != nil {
+		klog.Infof("%q not a duration: %v", s, err)
+		return time.Time{}, err
+	}
+	return parsed, nil
+}
+
 func runLeaderBoard(rootOpts *rootOptions) error {
-	ctx := context.Background()
-	c, err := client.New(ctx, client.Config{GitHubTokenPath: rootOpts.tokenPath})
+	var err error
+
+	sinceParsedDisplay, err = stringToTime(sinceDisplay, rootOpts.sinceParsed)
+	if err != nil {
+		return err
+	}
+	untilParsedDisplay, err = stringToTime(untilDisplay, rootOpts.untilParsed)
 	if err != nil {
 		return err
 	}
 
-	prs, err := summary.Pulls(ctx, c, rootOpts.repos, rootOpts.users, rootOpts.branches, rootOpts.sinceParsed, rootOpts.untilParsed)
+	d, err := dataFromGitHub()
+	if err != nil {
+		return err
+	}
+	d, err = appendJSONFiles(d)
 	if err != nil {
 		return err
 	}
 
-	reviews, err := summary.Reviews(ctx, c, rootOpts.repos, rootOpts.users, rootOpts.sinceParsed, rootOpts.untilParsed)
-	if err != nil {
-		return err
-	}
-
-	issues, err := summary.Issues(ctx, c, rootOpts.repos, rootOpts.users, rootOpts.sinceParsed, rootOpts.untilParsed)
-	if err != nil {
-		return err
-	}
-
-	comments, err := summary.Comments(ctx, c, rootOpts.repos, rootOpts.users, rootOpts.sinceParsed, rootOpts.untilParsed)
-	if err != nil {
+	if err := writeToJSON(d); err != nil {
 		return err
 	}
 
@@ -85,10 +150,11 @@ func runLeaderBoard(rootOpts *rootOptions) error {
 
 	out, err := leaderboard.Render(leaderboard.Options{
 		Title:          title,
-		Since:          rootOpts.sinceParsed,
-		Until:          rootOpts.untilParsed,
+		Since:          sinceParsedDisplay,
+		Until:          untilParsedDisplay,
 		DisableCaching: disableCaching,
-	}, rootOpts.users, prs, reviews, issues, comments)
+		HideCommand:    hideCommand,
+	}, rootOpts.users, d.PRs, d.Reviews, d.Issues, d.Comments)
 	if err != nil {
 		return err
 	}
@@ -97,4 +163,63 @@ func runLeaderBoard(rootOpts *rootOptions) error {
 	fmt.Print(out)
 
 	return nil
+}
+
+func dataFromGitHub() (*data, error) {
+	ctx := context.Background()
+	c, err := client.New(ctx, client.Config{GitHubTokenPath: rootOpts.tokenPath})
+	if err != nil {
+		return nil, err
+	}
+
+	prs, err := summary.Pulls(ctx, c, rootOpts.repos, rootOpts.users, rootOpts.branches, rootOpts.sinceParsed, rootOpts.untilParsed)
+	if err != nil {
+		return nil, err
+	}
+
+	reviews, err := summary.Reviews(ctx, c, rootOpts.repos, rootOpts.users, rootOpts.sinceParsed, rootOpts.untilParsed)
+	if err != nil {
+		return nil, err
+	}
+
+	issues, err := summary.Issues(ctx, c, rootOpts.repos, rootOpts.users, rootOpts.sinceParsed, rootOpts.untilParsed)
+	if err != nil {
+		return nil, err
+	}
+
+	comments, err := summary.Comments(ctx, c, rootOpts.repos, rootOpts.users, rootOpts.sinceParsed, rootOpts.untilParsed)
+	if err != nil {
+		return nil, err
+	}
+
+	return &data{prs, reviews, issues, comments}, nil
+}
+
+func appendJSONFiles(d *data) (*data, error) {
+	for _, file := range jsonFiles {
+		b, err := os.ReadFile(file)
+		if err != nil {
+			return nil, err
+		}
+		var u data
+		if err := json.Unmarshal(b, &u); err != nil {
+			return nil, err
+		}
+		d.PRs = append(d.PRs, u.PRs...)
+		d.Reviews = append(d.Reviews, u.Reviews...)
+		d.Issues = append(d.Issues, u.Issues...)
+		d.Comments = append(d.Comments, u.Comments...)
+	}
+	return d, nil
+}
+
+func writeToJSON(d *data) error {
+	if jsonOutput == "" {
+		return nil
+	}
+	b, err := json.Marshal(d)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(jsonOutput, b, 0644)
 }

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,6 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/viper v1.7.1
 	golang.org/x/oauth2 v0.0.0-20210323180902-22b0adad7558
-	k8s.io/klog v1.0.0 // indirect
-	k8s.io/klog/v2 v2.0.0 // indirect
+	golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c // indirect
+	k8s.io/klog/v2 v2.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -269,7 +269,6 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
-github.com/sirupsen/logrus v1.2.0 h1:juTguoYk5qI21pwyTXY3B3Y5cOTH3ZUyZCg1v/mihuo=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
@@ -435,8 +434,9 @@ golang.org/x/sys v0.0.0-20200501052902-10377860bb8e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200511232937-7e40ca221e25/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200803210538-64077c9b5642 h1:B6caxRw+hozq68X2MY7jEpZh/cr4/aHLv9xU8Kkadrw=
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c h1:aFV+BgZ4svzjfabn8ERpuB4JI4N6/rdy1iusx77G3oU=
+golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -601,8 +601,6 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
-k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog/v2 v2.0.0 h1:Foj74zO6RbjjP4hBEKjnYtjjAhGg4jNynUdYF6fJrok=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=

--- a/pkg/leaderboard/leaderboard.go
+++ b/pkg/leaderboard/leaderboard.go
@@ -38,6 +38,7 @@ type Options struct {
 	Since          time.Time
 	Until          time.Time
 	DisableCaching bool
+	HideCommand    bool
 }
 
 type category struct {
@@ -72,6 +73,7 @@ func Render(options Options, users []string, prs []*repo.PRSummary, reviews []*r
 		Until          string
 		DisableCaching bool
 		Command        string
+		HideCommand    bool
 		Categories     []category
 	}{
 		Title:          options.Title,
@@ -79,6 +81,7 @@ func Render(options Options, users []string, prs []*repo.PRSummary, reviews []*r
 		Until:          options.Until.Format(dateForm),
 		DisableCaching: options.DisableCaching,
 		Command:        filepath.Base(os.Args[0]) + " " + strings.Join(os.Args[1:], " "),
+		HideCommand:    options.HideCommand,
 		Categories: []category{
 			{
 				Title: "Reviewers",

--- a/pkg/leaderboard/leaderboard_templage.go
+++ b/pkg/leaderboard/leaderboard_templage.go
@@ -103,10 +103,10 @@ const leaderboardTmpl = `<html>
 <body>
     <h1>{{ .Title }}</h1>
     <div class="subtitle">{{.From}} &mdash; {{.Until}}</div>
-
+{{ if not .HideCommand }}
     <h2 class="cli">Command-line</h2>
     <pre>{{.Command}}</pre>
-
+{{ end }}
     {{ range .Categories }}
         <h2>{{ .Title }}</h2>
 

--- a/pkg/print/print.go
+++ b/pkg/print/print.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 
 	"github.com/gocarina/gocsv"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // This method prints the values in "data" interface to standatrd output in the format specified by "out_type", either JSON/CSV

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -26,7 +26,7 @@ import (
 	"github.com/google/pullsheet/pkg/server/job"
 	"github.com/google/pullsheet/pkg/server/site"
 	"github.com/karrick/tparse"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 const dateForm = "2006-01-02"

--- a/pkg/summary/summary.go
+++ b/pkg/summary/summary.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	"github.com/google/go-github/v33/github"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"github.com/google/pullsheet/pkg/client"
 	"github.com/google/pullsheet/pkg/repo"


### PR DESCRIPTION
**Changes:**
- Replaced leftover instances of `k8s.io/klog` with `k8s.io/klog/v2`
  - Resulted in `k8s.io/klog` module being removed from project
- Added support for Go 1.18
  - Done by running `go get -u golang.org/x/sys`
- Added `hide-command` flag to `leaderboard` command
  - Hides the `Command-line` line from the HTML output specifying what args were passed in
  - This is useful if the output is going to be public
- Added `json-output` flag to `leaderboard` command
  - This will write the output in JSON to the file specified
  - Will skip writing JSON if flag is empty (default)
- Added `json-files` flag to `leaderboard` command
  - Will append data from previously generated JSON files (`--json-output`) to new JSON and HTML output
    - ie. Assuming your have a JSON file already containing data from January - March, you can query April from GitHub and then append the previous months, resulting in a leaderboard from January - April
  - This is useful if you want to update the results say every month, you can save the previous data in JSON and then combine it with the new data and generate an updated HTML
- Added `since-display` & `until-display` flags to `leaderboard` command
  - These flags will override the `since` and `until` flag values that are listed as the date range on the leaderboard
  - This is so if appending previous data the date will match the true data
  - This does not modify the query dates for GitHub, just the display on the HTML