### PR TITLE
Add --org option to run report of all repos in an org

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,16 @@ You will need a GitHub authentication token from https://github.com/settings/tok
 
 ## Example: Merged PRs for 1 person across repos
 
-`go run pullsheet.go prs --repos kubernetes/minikube,GoogleContainerTools/skaffold --since 2019-10-01 --token-path /path/to/github/token/file --user someone > someone.csv`
+`go run pullsheet.go prs --repos kubernetes/minikube,GoogleContainerTools/skaffold --since 2019-10-01 --token-path /path/to/github/token/file --users someone > someone.csv`
 
 ## Example: Merged PR Reviews for all users in a repo
 
 `go run pullsheet.go reviews --repos kubernetes/minikube --kind=reviews --since 2020-12-24 --token-path /path/to/github/token/file > reviews.csv`
+
+## Example: Merged PRs for a user in all repos within an org
+
+`go run pullsheet.go prs --org google  --since 2020-12-24 --token-path /path/to/github/token/file > reviews.csv`
+
 
 ## CSV fields
 

--- a/cmd/prs.go
+++ b/cmd/prs.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/google/pullsheet/pkg/print"
+	"github.com/google/pullsheet/pkg/repo"
 	"github.com/google/pullsheet/pkg/summary"
 	"github.com/spf13/cobra"
 
@@ -46,7 +47,15 @@ func runPRs(rootOpts *rootOptions) error {
 		return err
 	}
 
-	data, err := summary.Pulls(ctx, c, rootOpts.repos, rootOpts.users, rootOpts.branches, rootOpts.sinceParsed, rootOpts.untilParsed)
+	var repos []string
+
+	if len(rootOpts.org) > 0 {
+		repos, err = repo.ListRepoNames(ctx, c, rootOpts.org)
+	} else {
+		repos = rootOpts.repos
+	}
+
+	data, err := summary.Pulls(ctx, c, repos, rootOpts.users, rootOpts.branches, rootOpts.sinceParsed, rootOpts.untilParsed)
 	if err != nil {
 		return err
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,6 +38,7 @@ pullsheet generates a CSV (comma separated values) & HTML output about GitHub ac
 }
 
 type rootOptions struct {
+	org         string
 	repos       []string
 	users       []string
 	since       string
@@ -65,6 +66,13 @@ func init() {
 	klog.InitFlags(nil)
 
 	rootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
+
+	rootCmd.PersistentFlags().StringVar(
+		&rootOpts.org,
+		"org",
+		"",
+		"github org name",
+	)
 
 	rootCmd.PersistentFlags().StringSliceVar(
 		&rootOpts.repos,

--- a/pkg/repo/repos.go
+++ b/pkg/repo/repos.go
@@ -1,0 +1,53 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package repo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-github/v33/github"
+	"github.com/google/pullsheet/pkg/client"
+)
+
+// ListProjects returns a list of all projects for an org
+func ListRepoNames(ctx context.Context, c *client.Client, org string) ([]string, error) {
+
+	// Retrieve all the repositories of the specified Github organization
+	opt := &github.RepositoryListByOrgOptions{
+		ListOptions: github.ListOptions{PerPage: 10},
+	}
+
+	var allRepos []string
+
+	for {
+		repos, resp, err := c.GitHubClient.Repositories.ListByOrg(ctx, org, opt)
+		if err != nil {
+			fmt.Println(err)
+			return allRepos, err
+		}
+
+		for _, val := range repos {
+			allRepos = append(allRepos, org+"/"+val.GetName())
+		}
+
+		if resp.NextPage == 0 {
+			break
+		}
+		opt.Page = resp.NextPage
+	}
+
+	return allRepos, nil
+}


### PR DESCRIPTION
We add the option to run for all repos in an organisation by passing in the `org` param:

```
go run pullsheet.go prs --org google --since 2020-12-24 --token-path /path/to/github/token/file > reviews.csv
```